### PR TITLE
Changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Ash Furrow <ash@ashfurrow.com>",
   "license": "MIT",
   "scripts": {
+    "precommit": "lint-staged"
   },
   "dependencies": {},
   "devDependencies": {
@@ -37,7 +38,7 @@
     "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json"]
   },
   "lint-staged": {
-    "*.@(ts|tsx)": ["yarn prettier --write", "git add"],
+    "*.@(ts|tsx)": ["yarn prettier --write", "jest", "git add"],
     "*.json": ["yarn prettier --write", "git add"]
   }
 }

--- a/pr.ts
+++ b/pr.ts
@@ -19,6 +19,7 @@ const wrap: any = isJest ? _test : _run
 
 // See: https://github.com/artsy/artsy-danger/blob/f019ee1a3abffabad65014afabe07cb9a12274e7/org/all-prs.ts#L67-L85
 export const changelog = wrap("Require changelog entries on PRs with code changes", async () => {
+  // First we check if there is a changelog in the repository.
   const pr = danger.github.pr
   const changelogs = ["CHANGELOG.md", "changelog.md", "Changelog.md", "CHANGELOG.yml"]
 
@@ -29,11 +30,12 @@ export const changelog = wrap("Require changelog entries on PRs with code change
   if (hasChangelog) {
     const files = [...danger.git.modified_files, ...danger.git.created_files]
 
+    // Look for Swift files that aren't in a unit test directory.
     const hasCodeChanges = files.find(file => file.match(/.*\.swift/) && !file.match(/(test|spec)/i))
     const hasChangelogChanges = files.find(file => changelogs.includes(file))
 
     if (hasCodeChanges && !hasChangelogChanges) {
-      warn("It looks like code was changed without adding anything to the Changelog")
+      warn("It looks like code was changed without adding anything to the Changelog.")
     }
   }
 })

--- a/pr.ts
+++ b/pr.ts
@@ -40,7 +40,7 @@ export const changelog = wrap("Require changelog entries on PRs with code change
       if (markedTrivial) {
         markdown(baseMessage)
       } else {
-        warn(baseMessage + "If this is a trivial PR that doesn't need a changelog, add #trivial to the PR title.")
+        warn(baseMessage + "If this is a trivial PR that doesn't need a changelog, add #trivial to the PR title or body.")
       }
     }
   }

--- a/pr.ts
+++ b/pr.ts
@@ -2,7 +2,7 @@ import { schedule, danger, warn, fail } from "danger"
 
 // Hey there!
 //
-// When a PR is opened, this file gets run. It's not straightforward, try to 
+// When a PR is opened, this file gets run. It's not straightforward, try to
 // follow the changelog example and ignore the next four const lines.
 // The inspiration for this is https://github.com/artsy/artsy-danger/blob/f019ee1a3abffabad65014afabe07cb9a12274e7/org/all-prs.ts
 const isJest = typeof jest !== "undefined"
@@ -26,16 +26,20 @@ export const changelog = wrap("Require changelog entries on PRs with code change
   const getContentParams = { path: "", owner: pr.head.user.login, repo: pr.head.repo.name }
   const rootContents: any = await danger.github.api.repos.getContent(getContentParams)
 
-  const hasChangelog = rootContents.data.find(file => changelogs.includes(file.name))
-  if (hasChangelog) {
+  const hasChangelog = rootContents.data.find((file: any) => changelogs.includes(file.name))
+  const markedTrivial = pr.title.match("#trivial")
+  if (hasChangelog && !markedTrivial) {
     const files = [...danger.git.modified_files, ...danger.git.created_files]
 
     // Look for Swift files that aren't in a unit test directory.
-    const hasCodeChanges = files.find(file => file.match(/.*\.swift/) && !file.match(/(test|spec)/i))
+    const hasCodeChanges = files.find((file: any) => file.match(/.*\.swift/) && !file.match(/(test|spec)/i))
     const hasChangelogChanges = files.find(file => changelogs.includes(file))
 
     if (hasCodeChanges && !hasChangelogChanges) {
-      warn("It looks like code was changed without adding anything to the Changelog.")
+      warn(
+        "It looks like code was changed without adding anything to the Changelog." +
+          "If this is a trivial PR that doesn't need a changelog, add #trivial to the PR title."
+      )
     }
   }
 })

--- a/pr.ts
+++ b/pr.ts
@@ -2,7 +2,7 @@ import { schedule, danger, warn, fail, markdown } from "danger"
 
 // Hey there!
 //
-// When a PR is opened, this file gets run. It's notrueo
+// When a PR is opened, this file gets run. It's not very straighforward, but
 // follow the changelog example and ignore the next four const lines.
 // The inspiration for this is https://github.com/artsy/artsy-danger/blob/f019ee1a3abffabad65014afabe07cb9a12274e7/org/all-prs.ts
 const isJest = typeof jest !== "undefined"
@@ -27,7 +27,7 @@ export const changelog = wrap("Require changelog entries on PRs with code change
   const rootContents: any = await danger.github.api.repos.getContent(getContentParams)
 
   const hasChangelog = rootContents.data.find((file: any) => changelogs.includes(file.name))
-  const markedTrivial = [pr.title, pr.body].find(s => s.includes("#trivial"))
+  const markedTrivial = (pr.title + pr.body).includes("#trivial")
   if (hasChangelog) {
     const files = [...danger.git.modified_files, ...danger.git.created_files]
 
@@ -40,9 +40,7 @@ export const changelog = wrap("Require changelog entries on PRs with code change
       if (markedTrivial) {
         markdown(baseMessage)
       } else {
-        warn(baseMessage +
-            "If this is a trivial PR that doesn't need a changelog, add #trivial to the PR title."
-        )
+        warn(baseMessage + "If this is a trivial PR that doesn't need a changelog, add #trivial to the PR title.")
       }
     }
   }

--- a/pr.ts
+++ b/pr.ts
@@ -1,3 +1,39 @@
-import { markdown, warn } from "danger"
+import { schedule, danger, warn, fail } from "danger"
 
-// TODO: Add a check to see if a changelog exists, then warn if it isn't in modified etc
+// Hey there!
+//
+// When a PR is opened, this file gets run. It's not straightforward, try to 
+// follow the changelog example and ignore the next four const lines.
+// The inspiration for this is https://github.com/artsy/artsy-danger/blob/f019ee1a3abffabad65014afabe07cb9a12274e7/org/all-prs.ts
+const isJest = typeof jest !== "undefined"
+// Stores the parameter in a closure that can be invoked in tests.
+const _test = (reason: string, closure: () => void | Promise<any>) =>
+  // We return a closure here so that the (promise is resolved|closure is invoked)
+  // during test time and not when we call rfc().
+  () => (closure instanceof Promise ? closure : Promise.resolve(closure()))
+// Either schedules the promise for execution via Danger, or invokes closure.
+const _run = (reason: string, closure: () => void | Promise<any>) =>
+  closure instanceof Promise ? schedule(closure) : closure()
+
+const wrap: any = isJest ? _test : _run
+
+// See: https://github.com/artsy/artsy-danger/blob/f019ee1a3abffabad65014afabe07cb9a12274e7/org/all-prs.ts#L67-L85
+export const changelog = wrap("Require changelog entries on PRs with code changes", async () => {
+  const pr = danger.github.pr
+  const changelogs = ["CHANGELOG.md", "changelog.md", "Changelog.md", "CHANGELOG.yml"]
+
+  const getContentParams = { path: "", owner: pr.head.user.login, repo: pr.head.repo.name }
+  const rootContents: any = await danger.github.api.repos.getContent(getContentParams)
+
+  const hasChangelog = rootContents.data.find(file => changelogs.includes(file.name))
+  if (hasChangelog) {
+    const files = [...danger.git.modified_files, ...danger.git.created_files]
+
+    const hasCodeChanges = files.find(file => file.match(/.*\.swift/) && !file.match(/(test|spec)/i))
+    const hasChangelogChanges = files.find(file => changelogs.includes(file))
+
+    if (hasCodeChanges && !hasChangelogChanges) {
+      warn("It looks like code was changed without adding anything to the Changelog")
+    }
+  }
+})

--- a/pr.ts
+++ b/pr.ts
@@ -2,7 +2,7 @@ import { schedule, danger, warn, fail, markdown } from "danger"
 
 // Hey there!
 //
-// When a PR is opened, this file gets run. It's not straightforward, try to
+// When a PR is opened, this file gets run. It's notrueo
 // follow the changelog example and ignore the next four const lines.
 // The inspiration for this is https://github.com/artsy/artsy-danger/blob/f019ee1a3abffabad65014afabe07cb9a12274e7/org/all-prs.ts
 const isJest = typeof jest !== "undefined"
@@ -27,7 +27,7 @@ export const changelog = wrap("Require changelog entries on PRs with code change
   const rootContents: any = await danger.github.api.repos.getContent(getContentParams)
 
   const hasChangelog = rootContents.data.find((file: any) => changelogs.includes(file.name))
-  const markedTrivial = pr.title.match("#trivial")
+  const markedTrivial = [pr.title, pr.body].find(s => s.includes("#trivial"))
   if (hasChangelog) {
     const files = [...danger.git.modified_files, ...danger.git.created_files]
 

--- a/pr.ts
+++ b/pr.ts
@@ -1,4 +1,4 @@
-import { schedule, danger, warn, fail } from "danger"
+import { schedule, danger, warn, fail, markdown } from "danger"
 
 // Hey there!
 //
@@ -28,7 +28,7 @@ export const changelog = wrap("Require changelog entries on PRs with code change
 
   const hasChangelog = rootContents.data.find((file: any) => changelogs.includes(file.name))
   const markedTrivial = pr.title.match("#trivial")
-  if (hasChangelog && !markedTrivial) {
+  if (hasChangelog) {
     const files = [...danger.git.modified_files, ...danger.git.created_files]
 
     // Look for Swift files that aren't in a unit test directory.
@@ -36,10 +36,14 @@ export const changelog = wrap("Require changelog entries on PRs with code change
     const hasChangelogChanges = files.find(file => changelogs.includes(file))
 
     if (hasCodeChanges && !hasChangelogChanges) {
-      warn(
-        "It looks like code was changed without adding anything to the Changelog." +
-          "If this is a trivial PR that doesn't need a changelog, add #trivial to the PR title."
-      )
+      const baseMessage = "It looks like code was changed without adding anything to the Changelog. "
+      if (markedTrivial) {
+        markdown(baseMessage)
+      } else {
+        warn(baseMessage +
+            "If this is a trivial PR that doesn't need a changelog, add #trivial to the PR title."
+        )
+      }
     }
   }
 })

--- a/tests/changelog.test.ts
+++ b/tests/changelog.test.ts
@@ -18,6 +18,7 @@ const pr = {
       name: "danger-js",
     },
   },
+  title: "This is the pull request title.",
 }
 
 it("warns when code has changed but no changelog entry was made", () => {
@@ -74,7 +75,6 @@ it("does nothing when only non-Swift files were changed", () => {
   })
 })
 
-
 it("does nothing when only `test` files were changed", () => {
   dm.danger.github = {
     api: {
@@ -93,7 +93,6 @@ it("does nothing when only `test` files were changed", () => {
   })
 })
 
-
 it("does nothing when the changelog was changed", () => {
   dm.danger.github = {
     api: {
@@ -105,6 +104,27 @@ it("does nothing when the changelog was changed", () => {
   }
   dm.danger.git = {
     modified_files: ["src/index.html", "CHANGELOG.md"],
+    created_files: [],
+  }
+  return changelog().then(() => {
+    expect(dm.warn).not.toBeCalled()
+  })
+})
+
+it("does nothing if the PR is marked a #trivial", () => {
+  dm.danger.github = {
+    api: {
+      repos: {
+        getContent: () => Promise.resolve({ data: [{ name: "code.swift" }, { name: "CHANGELOG.md" }] }),
+      },
+    },
+    pr: {
+      ...pr,
+      title: "Just fixing some typos #trivial",
+    },
+  }
+  dm.danger.git = {
+    modified_files: ["code.swift"],
     created_files: [],
   }
   return changelog().then(() => {

--- a/tests/changelog.test.ts
+++ b/tests/changelog.test.ts
@@ -85,7 +85,7 @@ it("does nothing when only `test` files were changed", () => {
     pr,
   }
   dm.danger.git = {
-    modified_files: ["tests/AuctionCalculatorSpec.scala"],
+    modified_files: ["Tests/CalculatorSpec.swift"],
     created_files: [],
   }
   return changelog().then(() => {

--- a/tests/changelog.test.ts
+++ b/tests/changelog.test.ts
@@ -1,0 +1,113 @@
+jest.mock("danger", () => jest.fn())
+import * as danger from "danger"
+const dm = danger as any
+
+import { changelog } from "../pr"
+
+beforeEach(() => {
+  dm.danger = {}
+  dm.warn = jest.fn()
+})
+
+const pr = {
+  head: {
+    user: {
+      login: "danger",
+    },
+    repo: {
+      name: "danger-js",
+    },
+  },
+}
+
+it("warns when code has changed but no changelog entry was made", () => {
+  dm.danger.github = {
+    api: {
+      repos: {
+        getContent: () => Promise.resolve({ data: [{ name: "code.swift" }, { name: "CHANGELOG.md" }] }),
+      },
+    },
+    pr,
+  }
+  dm.danger.git = {
+    modified_files: ["code.swift"],
+    created_files: [],
+  }
+  return changelog().then(() => {
+    expect(dm.warn).toBeCalled()
+  })
+})
+
+it("does nothing when there is no changelog file", () => {
+  dm.danger.github = {
+    api: {
+      repos: {
+        getContent: () => Promise.resolve({ data: [{ name: "code.js" }] }),
+      },
+    },
+    pr,
+  }
+  dm.danger.git = {
+    modified_files: [],
+    created_files: [],
+  }
+  return changelog().then(() => {
+    expect(dm.warn).not.toBeCalled()
+  })
+})
+
+it("does nothing when only non-Swift files were changed", () => {
+  dm.danger.github = {
+    api: {
+      repos: {
+        getContent: () => Promise.resolve({ data: [{ name: "CHANGELOG.md" }] }),
+      },
+    },
+    pr,
+  }
+  dm.danger.git = {
+    modified_files: ["Podfile"],
+    created_files: [],
+  }
+  return changelog().then(() => {
+    expect(dm.warn).not.toBeCalled()
+  })
+})
+
+
+it("does nothing when only `test` files were changed", () => {
+  dm.danger.github = {
+    api: {
+      repos: {
+        getContent: () => Promise.resolve({ data: [{ name: "CHANGELOG.md" }] }),
+      },
+    },
+    pr,
+  }
+  dm.danger.git = {
+    modified_files: ["tests/AuctionCalculatorSpec.scala"],
+    created_files: [],
+  }
+  return changelog().then(() => {
+    expect(dm.warn).not.toBeCalled()
+  })
+})
+
+
+it("does nothing when the changelog was changed", () => {
+  dm.danger.github = {
+    api: {
+      repos: {
+        getContent: () => Promise.resolve({ data: [{ name: "code.js" }, { name: "CHANGELOG.md" }] }),
+      },
+    },
+    pr,
+  }
+  dm.danger.git = {
+    modified_files: ["src/index.html", "CHANGELOG.md"],
+    created_files: [],
+  }
+  return changelog().then(() => {
+    expect(dm.warn).not.toBeCalled()
+  })
+})

--- a/tests/changelog.test.ts
+++ b/tests/changelog.test.ts
@@ -20,6 +20,7 @@ const pr = {
     },
   },
   title: "This is the pull request title.",
+  body: "",
 }
 
 it("warns when code has changed but no changelog entry was made", () => {
@@ -112,7 +113,7 @@ it("does nothing when the changelog was changed", () => {
   })
 })
 
-it("sends a message if the PR is marked a #trivial", () => {
+it("sends a message if the PR title includes #trivial", () => {
   dm.danger.github = {
     api: {
       repos: {
@@ -122,6 +123,28 @@ it("sends a message if the PR is marked a #trivial", () => {
     pr: {
       ...pr,
       title: "Just fixing some typos #trivial",
+    },
+  }
+  dm.danger.git = {
+    modified_files: ["code.swift"],
+    created_files: [],
+  }
+  return changelog().then(() => {
+    expect(dm.markdown).toBeCalled()
+  })
+})
+
+it("sends a message if the PR body includes #trivial", () => {
+  dm.danger.github = {
+    api: {
+      repos: {
+        getContent: () => Promise.resolve({ data: [{ name: "code.swift" }, { name: "CHANGELOG.md" }] }),
+      },
+    },
+    pr: {
+      ...pr,
+      title: "Just fixing some typos",
+      body: "Nothing fancy, pretty #trivial",
     },
   }
   dm.danger.git = {

--- a/tests/changelog.test.ts
+++ b/tests/changelog.test.ts
@@ -7,6 +7,7 @@ import { changelog } from "../pr"
 beforeEach(() => {
   dm.danger = {}
   dm.warn = jest.fn()
+  dm.markdown = jest.fn()
 })
 
 const pr = {
@@ -111,7 +112,7 @@ it("does nothing when the changelog was changed", () => {
   })
 })
 
-it("does nothing if the PR is marked a #trivial", () => {
+it("sends a message if the PR is marked a #trivial", () => {
   dm.danger.github = {
     api: {
       repos: {
@@ -128,6 +129,6 @@ it("does nothing if the PR is marked a #trivial", () => {
     created_files: [],
   }
   return changelog().then(() => {
-    expect(dm.warn).not.toBeCalled()
+    expect(dm.markdown).toBeCalled()
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "lib": ["es2017"],
+    "strict": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3630,7 +3630,7 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vm2@github:patriksimek/vm2#custom_files":
+vm2@patriksimek/vm2#custom_files:
   version "3.5.0"
   resolved "https://codeload.github.com/patriksimek/vm2/tar.gz/7e82f90ac705fc44fad044147cb0df09b4c79a57"
 


### PR DESCRIPTION
Okay so this PR is the RxSwiftCommunity's first contact with [Peril](https://github.com/danger/peril). What's Peril? In short, Peril is a server that runs on Heroku that gets notified by GitHub when new issues or pull requests are opened. That's useful for doing things like [inviting new members](https://github.com/RxSwiftCommunity/contributors/issues/36) (which is currently done through [Aeryn](https://github.com/Moya/Aeryn)), making sure that there are changelog entries for PRs (which this PR adds), or making sure that we remember to update Carthage files when Podspecs change ([see example](https://github.com/Moya/Moya/blob/03d9d62c87d716bcfb87ace18b88981b7f88aae5/Dangerfile#L42-L48)).

Currently, Peril only gets events for https://github.com/RxSwiftCommunity/contributors and you can see an example of what this looks like here: https://github.com/RxSwiftCommunity/contributors/pull/35

![screen shot 2017-12-30 at 11 39 58 pm](https://user-images.githubusercontent.com/498212/34459308-c70e1a10-edba-11e7-9ce1-71af9b5a8aa4.png)

So this PR adds the first danger rule for our community: making sure that changelog entries are present when non-testing code is changed (provided the repo contains a changelog at all).

This is a pretty big change for the org, so I wanted to flag this to @RxSwiftCommunity/contributors. I'm very happy to answer any questions or clarify any of the code below (it's a form of JavaScript, so if something doesn't make sense, please comment in-line). Once this PR gets merged, we can enable Peril org-wide.

Fixes https://github.com/RxSwiftCommunity/contributors/issues/28.