### PR TITLE
Adds Aeryn functionality.

### DIFF
--- a/org/aeryn.ts
+++ b/org/aeryn.ts
@@ -2,9 +2,6 @@
 
 import { schedule, danger, markdown } from "danger"
 
-// TODO: Needed?
-declare const peril: any // danger/danger#351
-
 // Hey there!
 //
 // When a PR is closed, this file gets run. The purpose of this file is to 

--- a/org/aeryn.ts
+++ b/org/aeryn.ts
@@ -1,0 +1,52 @@
+// For the inspiration for this file, see: https://github.com/danger/peril-settings/blob/fc0015452438c8a1624c0951a600f723f2e60fea/org/aeryn.ts#L18-L39
+
+import { schedule, danger, markdown } from "danger"
+
+// TODO: Needed?
+declare const peril: any // danger/danger#351
+
+// Hey there!
+//
+// When a PR is closed, this file gets run. The purpose of this file is to 
+// replicate Aeryn (https://github.com/Moya/Aeryn), which invites new 
+// contributors to join the organization after their first PR gets merged.
+//
+// Ignore the next four const lines.
+// The inspiration for this is https://github.com/artsy/artsy-danger/blob/f019ee1a3abffabad65014afabe07cb9a12274e7/org/all-prs.ts
+const isJest = typeof jest !== "undefined"
+// Returns the promise itself, for testing.
+const _test = (reason: string, promise: Promise<any>) => promise
+// Schedules the promise for execution via Danger.
+const _run = (reason: string, promise: Promise<any>) => schedule(promise)
+const wrap: any = isJest ? _test : _run
+
+export const aeryn = wrap("When a PR is merged, check if the author is in the org", async () => {
+  const pr = danger.github.pr
+  const username = pr.user.login
+  const api = danger.github.api
+
+  if (!pr.merged) {
+    // Only proceed if the PR was merged (as opposed to closed without merging).
+    return
+  }
+
+  const org = "RxSwiftCommunity"
+  const inviteMarkdown = `
+  Thanks a lot for contributing @${username}! I've invited you to join the 
+  RxSwiftCommunity GitHub organization – no pressure to accept! If you'd like 
+  more information on what this means, check out our [contributor guidelines][c]
+  and feel free to reach out with any questions.
+
+  [c]: https://github.com/RxSwiftCommunity/contributors
+  `
+
+  try {
+    // This throws if the user isn't a member of the org yet. If it doesn't
+    // throw, then it means the user was already invited or has already 
+    // accepted the invitation (we ignore the return value here).
+    await api.orgs.checkMembership({ org, username })
+  } catch (error) {
+    markdown(inviteMarkdown)
+    await api.orgs.addOrgMembership({ org, username, role: "member" })
+  }
+})

--- a/settings-peril.json
+++ b/settings-peril.json
@@ -4,7 +4,8 @@
   },
   "rules": {
     "pull_request": "RxSwiftCommunity/peril@org/all-prs.ts",
-    "issue": "RxSwiftCommunity/peril@org/all-issues.ts"
+    "issue": "RxSwiftCommunity/peril@org/all-issues.ts",
+    "pull_request.closed": "RxSwiftCommunity/peril@org/aeryn.ts"
   },
   "repos": {
   }

--- a/tests/aeryn.test.ts
+++ b/tests/aeryn.test.ts
@@ -1,0 +1,55 @@
+jest.mock("danger", () => jest.fn())
+import * as danger from "danger"
+const dm = danger as any
+
+import { aeryn } from "../org/aeryn"
+
+beforeEach(() => {
+  dm.danger = {
+    github: {
+      pr: {
+        user: {
+          login: "a_new_user",
+        },
+      }
+    }
+  }
+  dm.markdown = jest.fn()
+})
+
+it("doesn't do anything if the PR was closed without merging", () => {
+  return aeryn().then(() => {
+    expect(dm.markdown).not.toHaveBeenCalled()
+  })
+})
+
+describe("a merged PR", () => {
+  beforeEach(() => {
+    dm.danger.github.pr.merged = true
+  })
+
+  it("doesn't do anything if the user is already invited", () => {
+    dm.danger.github.api = {
+      orgs: {
+        checkMembership: async () => { }
+      }
+    }
+    return aeryn().then(() => {
+      expect(dm.markdown).not.toHaveBeenCalled()
+    })
+  })
+
+  it("invites the user", () => {
+    const inviteMock = jest.fn()
+    dm.danger.github.api = {
+      orgs: {
+        checkMembership: async () => { throw new Error("Not a member") },
+        addOrgMembership: inviteMock
+      }
+    }
+    return aeryn().then(() => {
+      expect(dm.markdown).toHaveBeenCalled()
+      expect(inviteMock).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
This PR adds functionality to automatically invite new contributors to the RxSwiftCommunity organization, replacing our Aeryn server. Tracked in https://github.com/RxSwiftCommunity/contributors/issues/36.

@orta there's one TODO that I copied from your implementation but I don't think it's required. Would you mind taking a quick look?