### PR TITLE
Add logic to automatically label issues as a question

### DIFF
--- a/org/labelissue.ts
+++ b/org/labelissue.ts
@@ -1,0 +1,30 @@
+import { danger, schedule } from "danger"
+
+const gh = danger.github as any
+const issue = gh.issue
+const repo = gh.repository
+
+const qWords: string[] = ["how", "who", "what", "where", "when", "why", "which"]
+
+if (issue.title.slice(-1) == "?") {
+  addLabel()
+} else {
+  const title = issue.title.toLowerCase()
+  for (var i = 0; i < qWords.length; i++) {
+    if (title.startsWith(qWords[i])) {
+      addLabel()
+      break
+    }
+  }
+}
+
+function addLabel() {
+  schedule(async () => {
+    await danger.github.api.issues.addLabels({
+      owner: repo.owner.login,
+      repo: repo.name,
+      number: issue.number,
+      labels: ["question"],
+    })
+  })
+}

--- a/settings-peril.json
+++ b/settings-peril.json
@@ -4,9 +4,9 @@
   },
   "rules": {
     "pull_request": "RxSwiftCommunity/peril@org/all-prs.ts",
+    "pull_request.closed": "RxSwiftCommunity/peril@org/aeryn.ts",
     "issue": "RxSwiftCommunity/peril@org/all-issues.ts",
-    "pull_request.closed": "RxSwiftCommunity/peril@org/aeryn.ts"
+    "issue.opened": "RxSwiftCommunity/peril@org/labelissue.ts"
   },
-  "repos": {
-  }
+  "repos": {}
 }


### PR DESCRIPTION
#### Add logic to automatically label issues as a question

This PR adds a new rule for `issues.opened` that automatically labels the issue as a question if it is able to do so. [I just added this to Moya](https://github.com/Moya/moya-peril/issues/2) and thought it could also provide value here.

Getting this running may depend on upgrading to the latest version of Peril.