### PR TITLE
Fix inviting bots

### DIFF
--- a/org/aeryn.ts
+++ b/org/aeryn.ts
@@ -4,8 +4,8 @@ import { schedule, danger, markdown } from "danger"
 
 // Hey there!
 //
-// When a PR is closed, this file gets run. The purpose of this file is to 
-// replicate Aeryn (https://github.com/Moya/Aeryn), which invites new 
+// When a PR is closed, this file gets run. The purpose of this file is to
+// replicate Aeryn (https://github.com/Moya/Aeryn), which invites new
 // contributors to join the organization after their first PR gets merged.
 //
 // Ignore the next four const lines.
@@ -27,6 +27,11 @@ export const aeryn = wrap("When a PR is merged, check if the author is in the or
     return
   }
 
+  if (pr.user.type !== "User") {
+    // Ignore PRs from bots.
+    return
+  }
+
   const org = "RxSwiftCommunity"
   const inviteMarkdown = `
   Thanks a lot for contributing @${username}! I've invited you to join the 
@@ -39,7 +44,7 @@ export const aeryn = wrap("When a PR is merged, check if the author is in the or
 
   try {
     // This throws if the user isn't a member of the org yet. If it doesn't
-    // throw, then it means the user was already invited or has already 
+    // throw, then it means the user was already invited or has already
     // accepted the invitation (we ignore the return value here).
     await api.orgs.checkMembership({ org, username })
   } catch (error) {

--- a/tests/aeryn.test.ts
+++ b/tests/aeryn.test.ts
@@ -10,9 +10,10 @@ beforeEach(() => {
       pr: {
         user: {
           login: "a_new_user",
+          type: "User",
         },
-      }
-    }
+      },
+    },
   }
   dm.markdown = jest.fn()
 })
@@ -28,11 +29,18 @@ describe("a merged PR", () => {
     dm.danger.github.pr.merged = true
   })
 
+  it("doesn't do anything if the PR was sent by a bot", () => {
+    dm.danger.github.pr.user.type = "Bot"
+    return aeryn().then(() => {
+      expect(dm.markdown).not.toHaveBeenCalled()
+    })
+  })
+
   it("doesn't do anything if the user is already invited", () => {
     dm.danger.github.api = {
       orgs: {
-        checkMembership: async () => { }
-      }
+        checkMembership: async () => {},
+      },
     }
     return aeryn().then(() => {
       expect(dm.markdown).not.toHaveBeenCalled()
@@ -43,9 +51,11 @@ describe("a merged PR", () => {
     const inviteMock = jest.fn()
     dm.danger.github.api = {
       orgs: {
-        checkMembership: async () => { throw new Error("Not a member") },
-        addOrgMembership: inviteMock
-      }
+        checkMembership: async () => {
+          throw new Error("Not a member")
+        },
+        addOrUpdateMembership: inviteMock,
+      },
     }
     return aeryn().then(() => {
       expect(dm.markdown).toHaveBeenCalled()

--- a/tests/changelog.test.ts
+++ b/tests/changelog.test.ts
@@ -27,7 +27,7 @@ it("warns when code has changed but no changelog entry was made", () => {
   dm.danger.github = {
     api: {
       repos: {
-        getContent: () => Promise.resolve({ data: [{ name: "code.swift" }, { name: "CHANGELOG.md" }] }),
+        getContents: () => Promise.resolve({ data: [{ name: "code.swift" }, { name: "CHANGELOG.md" }] }),
       },
     },
     pr,
@@ -45,7 +45,7 @@ it("does nothing when there is no changelog file", () => {
   dm.danger.github = {
     api: {
       repos: {
-        getContent: () => Promise.resolve({ data: [{ name: "code.js" }] }),
+        getContents: () => Promise.resolve({ data: [{ name: "code.js" }] }),
       },
     },
     pr,
@@ -63,7 +63,7 @@ it("does nothing when only non-Swift files were changed", () => {
   dm.danger.github = {
     api: {
       repos: {
-        getContent: () => Promise.resolve({ data: [{ name: "CHANGELOG.md" }] }),
+        getContents: () => Promise.resolve({ data: [{ name: "CHANGELOG.md" }] }),
       },
     },
     pr,
@@ -81,7 +81,7 @@ it("does nothing when only `test` files were changed", () => {
   dm.danger.github = {
     api: {
       repos: {
-        getContent: () => Promise.resolve({ data: [{ name: "CHANGELOG.md" }] }),
+        getContents: () => Promise.resolve({ data: [{ name: "CHANGELOG.md" }] }),
       },
     },
     pr,
@@ -99,7 +99,7 @@ it("does nothing when the changelog was changed", () => {
   dm.danger.github = {
     api: {
       repos: {
-        getContent: () => Promise.resolve({ data: [{ name: "code.js" }, { name: "CHANGELOG.md" }] }),
+        getContents: () => Promise.resolve({ data: [{ name: "code.js" }, { name: "CHANGELOG.md" }] }),
       },
     },
     pr,
@@ -117,7 +117,7 @@ it("sends a message if the PR title includes #trivial", () => {
   dm.danger.github = {
     api: {
       repos: {
-        getContent: () => Promise.resolve({ data: [{ name: "code.swift" }, { name: "CHANGELOG.md" }] }),
+        getContents: () => Promise.resolve({ data: [{ name: "code.swift" }, { name: "CHANGELOG.md" }] }),
       },
     },
     pr: {
@@ -138,7 +138,7 @@ it("sends a message if the PR body includes #trivial", () => {
   dm.danger.github = {
     api: {
       repos: {
-        getContent: () => Promise.resolve({ data: [{ name: "code.swift" }, { name: "CHANGELOG.md" }] }),
+        getContents: () => Promise.resolve({ data: [{ name: "code.swift" }, { name: "CHANGELOG.md" }] }),
       },
     },
     pr: {


### PR DESCRIPTION
I noticed that bots, like Depndabot, which sent PRs that got merged had Peril try to invite them to the GitHub organization. This would fail and  leave an error in the GitHub comment. [I applied this fix](https://github.com/ashfurrow/peril-settings/commit/dd009d37d5fae35fafba2b3ca043d32138902baa) to my personal Peril server and wanted to apply the change here as well.

I've sent [a PR to Moya](https://github.com/Moya/moya-peril/pull/49) as well. This PR also fixes tests locally, and I've opened #20 to track the CI upgrade.